### PR TITLE
Update GitHub Actions pipeline to use JDK 17 for compilation only

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,14 +8,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: ['11', '17']
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Java 11
+      - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java_version }}
 
       - name: Set up Maven cache
         uses: actions/cache@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           server-username: SONATYPE_USERNAME # env variable for username in deploy
           server-password: SONATYPE_PASSWORD # env variable for token in deploy


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

With JDK 17 released as the newest LTS version of Java, we want to build new artifacts with it. This PR changes the release workflow to compile with JDK 17, and changes the pull request workflow to test new PRs with both JDK 11 and JDK 17.

**Note: We will use JDK 17 for compilation only. Released byte-code will still be Java 11.**

### Changed
* GitHub Actions "Release" workflow uses JDK 17 for compilation
* GitHub Actions "Pull Request Check" workflow tests PRs with both JDK 11 and JDK 17


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Unit test(s) added
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation)
